### PR TITLE
Add webdriver-manager update in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "./node_modules/.bin/gulp serve",
     "test": "./node_modules/.bin/gulp jshint --env test && ./node_modules/.bin/gulp htmlhint --env test && ./node_modules/.bin/karma start --single-run --browsers PhantomJS --capture-console false",
     "test-unit": "./node_modules/.bin/karma start",
-    "postinstall": "./node_modules/.bin/jspm install",
+    "postinstall": "./node_modules/.bin/jspm install && ./node_modules/protractor/bin/webdriver-manager update",
     "test-build": "./bin/test-build.sh",
     "test-e2e": "./node_modules/.bin/protractor protractor.config.js",
     "forever-start-test": "echo \"Launching server (test mode) ...\" && ./node_modules/.bin/forever start ./test/forever.gulp.serve.test.json",


### PR DESCRIPTION
  I couldn't run e2e cause `/node_modules/protractor/selenium` was not
  found, so I found this comment http://git.io/vnjYx on gulp-protractor's
  issue, and it fixed my problem.

  I put that command in line 10, now every `npm install` will check to
  install or update selenium drivers.

  With this I could first run `gulp server` then `npm run test-e2e`
  and it worked, but some tests failed :)
