### PR TITLE
feat(*) don't execute e2e test on pull-requests - TEST PULL REQUEST

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 - gulp build
 - gulp clean
 - gulp build --env test
-- npm run forever-start-dist
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm run forever-start-dist || true'
 script:
 - npm test
 - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm run test-e2e || true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ before_script:
 - npm run forever-start-dist
 script:
 - npm test
-- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm run test-e2e || false'
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm run test-e2e || true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ before_script:
 - npm run forever-start-dist
 script:
 - npm test
-- npm run test-e2e
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && npm run test-e2e || false'


### PR DESCRIPTION
This is to test the pull request, to make sure the e2e tests won't execute on Travis.

Because of security reasons, Travis won't export secure token when executing builds from
pull-requests made from forks (not original repo).
This ends up not opening sauce connect tunnel, which fails the build.
This also doesn't export the Jspm registry config (which could lead to fail sometime ...)
- http://docs.travis-ci.com/user/pull-requests/
- https://github.com/topheman/vanilla-es6-jspm/pull/2#issuecomment-143497153
