### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ If either one of them fails, the build will be flagged as failed.
 
 *You can skip this if e2e testing isn't part of your Continuous Integration workflow.*
 
-SauceLabs is a cross-browser automation tool built on top of Selenium WebDriver (Protractor uses Selenium WebDriver). It lets you run e2e tests accross multiple devices and is well integrated to Travis CI.
+SauceLabs is a cross-browser automation tool built on top of Selenium WebDriver (Protractor uses Selenium WebDriver). It lets you run e2e tests across multiple devices and is well integrated to Travis CI.
 
 If you want to set it up for your own project, [read this post](http://dev.topheman.com/setup-travis-ci-saucelabs-for-protractor).
 


### PR DESCRIPTION
@topheman, I've corrected a typographical error in the documentation of the [vanilla-es6-jspm](https://github.com/topheman/vanilla-es6-jspm) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
